### PR TITLE
WOS-203: Replaces deprecated s3 command

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
   register: db_dump
 
 - name: Retrieve DB backup from s3
-  s3:
+  aws_s3:
     region: "{{ region }}"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"


### PR DESCRIPTION
https://beamly.atlassian.net/browse/WOS-203

New thinking for builds requires higher version of Vagrant which deprecates s3 module over aws_s3.